### PR TITLE
Transport/tests :cactus: 

### DIFF
--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -12,20 +12,32 @@ repositories {
 ext {
     junitVersion = '5.12.0'
     opensearchVersion = '2.9.0'
+    testcontainersVersion = '1.20.6'
+    httpClientVersion = '4.5.13'
+    postgresqlDriverVersion = '42.7.3'
+    opensearchtestcontainersVersion = '2.1.3'
 }
-
 
 dependencies {
     implementation project(":common")
     implementation project(":sdk")
-
-    // OpenSearch
     implementation "org.opensearch.client:opensearch-java:$opensearchVersion"
-
-    // JUnit 5
+    implementation "org.opensearch.client:opensearch-rest-client:$opensearchVersion"
+    implementation "org.apache.httpcomponents:httpclient:$httpClientVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.12.0"
+    testImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
+    testImplementation "org.testcontainers:testcontainers:$testcontainersVersion"
+    testImplementation "org.testcontainers:postgresql:$testcontainersVersion"
+    testImplementation "org.opensearch:opensearch-testcontainers:$opensearchtestcontainersVersion"
 }
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 test {
     useJUnitPlatform()
 }

--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -10,17 +10,19 @@ repositories {
 }
 
 ext {
+    jooqVersion = '3.19.7'
     junitVersion = '5.12.0'
-    opensearchVersion = '2.9.0'
-    testcontainersVersion = '1.20.6'
     httpClientVersion = '4.5.13'
     postgresqlDriverVersion = '42.7.3'
     opensearchtestcontainersVersion = '2.1.3'
+    opensearchVersion = '2.9.0'
+    testcontainersVersion = '1.20.6'
 }
 
 dependencies {
     implementation project(":common")
     implementation project(":sdk")
+    implementation "org.jooq:jooq:$jooqVersion"
     implementation "org.opensearch.client:opensearch-java:$opensearchVersion"
     implementation "org.opensearch.client:opensearch-rest-client:$opensearchVersion"
     implementation "org.apache.httpcomponents:httpclient:$httpClientVersion"
@@ -31,7 +33,9 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:$testcontainersVersion"
     testImplementation "org.testcontainers:postgresql:$testcontainersVersion"
     testImplementation "org.opensearch:opensearch-testcontainers:$opensearchtestcontainersVersion"
+    testRuntimeOnly "org.postgresql:postgresql:$postgresqlDriverVersion"
 }
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -35,19 +35,18 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
 
     @Override
     public String requestUrl(RequestT request) throws IllegalArgumentException {
-        List<String> AA = List.of(endpoint.requestUrl(request).split("/"));
+        List<String> splitedPath = List.of(endpoint.requestUrl(request).split("/"));
         List<String> Indecies = parseUrl(endpoint.requestUrl(request));
         StringBuilder answer = new StringBuilder("/" + String.join("%2C", Indecies));
-        if (AA.size() <= 2) {
+        if (splitedPath.size() <= 2) {
             return answer.toString();
         }
         answer.append("/");
-        for (int i = 2; i < AA.size() - 1; i++) {
-            answer.append(AA.get(i)).append("/");
+        for (int i = 2; i < splitedPath.size() - 1; i++) {
+            answer.append(splitedPath.get(i)).append("/");
         }
-        answer.append(AA.getLast());
-        String a = answer.toString();
-        return a;
+        answer.append(splitedPath.getLast());
+        return answer.toString();
     }
 
     @Override

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -60,23 +60,15 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
     @Override
     public Map<String, String> queryParameters(RequestT request) {
         Map<String, String> a =endpoint.queryParameters(request);
-        for (var x: a.keySet()){
-            System.out.println(x +"   "+ a.get(x));
-        }
         Map<String, String> params = endpoint.queryParameters(request);
         QueryMapper mapper = new QueryMapper();
         Query query = mapper.mapToQuery(params);
         Map<String, String> answer = new HashMap<>();
         List<String> Indecies = parseUrl(endpoint.requestUrl(request));
         for(var x: Indecies) {
-            System.out.println(x+"cacab");
-          //  query = sdk.addIndexFilter(query,x);
+          // query = sdk.addIndexFilter(query,x);
         }
         mapper.queryToMap(query, answer);
-        System.out.println(answer.keySet());
-        for (var x: answer.keySet()){
-            System.out.println(x +"   "+ answer.get(x));
-        }
         return answer;
     }
 

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -1,23 +1,15 @@
 package com.omnia.transport;
 
 
-import org.jooq.Null;
 import org.opensearch.client.json.JsonpDeserializer;
-import org.opensearch.client.json.UnexpectedJsonEventException;
-import org.opensearch.client.opensearch._types.FieldValue;
-import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch._types.query_dsl.*;
-import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.transport.Endpoint;
 
 import com.omnia.sdk.OmniaSDK;
 import org.opensearch.client.transport.JsonEndpoint;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<RequestT, ResponseT, ErrorT>, JsonEndpoint<RequestT, ResponseT, ErrorT> {
     private final Endpoint<RequestT, ResponseT, ErrorT> endpoint;

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -103,13 +103,14 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
         return endpoint.errorDeserializer(statusCode);
     }
 
-    public List<String> getIndex(String path){
+    public List<String> getIndex(String path) {
         List<String> parsePath = List.of(path.split("/"));
         if (parsePath.getFirst() == null) {
             throw new IllegalArgumentException();
         }
         return List.of(parsePath.get(1).split("%2C"));
     }
+
     private List<String> parseUrl(String path) {
         List<String> answer = new ArrayList<>();
         for (var x : getIndex(path)) {

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -51,30 +51,6 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
 
     @Override
     public Map<String, String> queryParameters(RequestT request) {
-        /*
-        Map<String, String> a = endpoint.queryParameters(request);
-        for(var x: a.keySet()){
-            System.out.println(x+" "+a.get(x));
-        }
-        Map<String, String> params = endpoint.queryParameters(request);
-        QueryMapper mapper = new QueryMapper();
-        Query query = mapper.mapToQuery(params);
-        Map<String, String> answer = new HashMap<>();
-        List<String> parsePath = List.of(endpoint.requestUrl(request).split("/"));
-        List<String> Indecies = List.of(parsePath.get(1).split("%2C"));
-        for (var x : Indecies) {
-            if(request instanceof SearchRequest) {
-                query = sdk.addIndexFilter(query, x);
-                // Проблема. Кажется, что endpoint.queryParameters не все параметры Query -> если добавлять в endpoint.queryParameters лишнее падаем с исключением от RestTransport
-            }
-        }
-
-        mapper.queryToMap(query, answer);
-        for(var x: answer.keySet()){
-              System.out.println("Answer: "+x+" "+answer.get(x));
-        }
-        return answer;
-         */
         return endpoint.queryParameters(request);
     }
 

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -41,7 +41,7 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
         Query query = mapper.mapToQuery(params);
         Map<String, String> answer = new HashMap<>();
         query = sdk.addIndexFilter(query, endpoint.requestUrl(request));
-        mapper.queryToMap(query,answer);
+        mapper.queryToMap(query, answer);
         return answer;
     }
 

--- a/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaEndpoint.java
@@ -22,7 +22,7 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
     private final Endpoint<RequestT, ResponseT, ErrorT> endpoint;
     private final OmniaSDK sdk;
 
-    public OmniaEndpoint(Endpoint<RequestT, ResponseT, ErrorT>  endpoint, OmniaSDK sdk) {
+    public OmniaEndpoint(Endpoint<RequestT, ResponseT, ErrorT> endpoint, OmniaSDK sdk) {
         this.endpoint = endpoint;
         this.sdk = sdk;
     }
@@ -37,20 +37,20 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
         List<String> AA = List.of(endpoint.requestUrl(request).split("/"));
         List<String> Indecies = parseUrl(endpoint.requestUrl(request));
         List<String> newIndecies = new ArrayList<>();
-        for(var x: Indecies){
+        for (var x : Indecies) {
             String newIndex = sdk.transformIndexId(x);
-            if(newIndex== null){
+            if (newIndex == null) {
                 newIndecies.add(x);
                 continue;
             }
             newIndecies.add(newIndex);
         }
         String answer = "/" + String.join("%2C", newIndecies);
-        if(AA.size()<=2){
+        if (AA.size() <= 2) {
             return answer;
         }
-        answer+="/";
-        for(int i=2;i<AA.size() -1;i++){
+        answer += "/";
+        for (int i = 2; i < AA.size() - 1; i++) {
             answer += AA.get(i) + "/";
         }
         answer += AA.getLast();
@@ -59,14 +59,14 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
 
     @Override
     public Map<String, String> queryParameters(RequestT request) {
-        Map<String, String> a =endpoint.queryParameters(request);
+        Map<String, String> a = endpoint.queryParameters(request);
         Map<String, String> params = endpoint.queryParameters(request);
         QueryMapper mapper = new QueryMapper();
         Query query = mapper.mapToQuery(params);
         Map<String, String> answer = new HashMap<>();
         List<String> Indecies = parseUrl(endpoint.requestUrl(request));
-        for(var x: Indecies) {
-          // query = sdk.addIndexFilter(query,x);
+        for (var x : Indecies) {
+            // query = sdk.addIndexFilter(query,x);
         }
         mapper.queryToMap(query, answer);
         return answer;
@@ -74,11 +74,10 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
 
     @Override
     public Map<String, String> headers(RequestT request) {
-        if( endpoint instanceof JsonEndpoint<RequestT,ResponseT,ErrorT>) {
+        if (endpoint instanceof JsonEndpoint<RequestT, ResponseT, ErrorT>) {
             return endpoint.headers(request);
-        }
-        else{
-                throw new IllegalArgumentException("Expected JsonEndpooint");
+        } else {
+            throw new IllegalArgumentException("Expected JsonEndpooint");
         }
     }
 
@@ -108,10 +107,9 @@ public class OmniaEndpoint<RequestT, ResponseT, ErrorT> implements Endpoint<Requ
 
     @Override
     public JsonpDeserializer<ResponseT> responseDeserializer() {
-        if( endpoint instanceof JsonEndpoint<RequestT,ResponseT,ErrorT>) {
+        if (endpoint instanceof JsonEndpoint<RequestT, ResponseT, ErrorT>) {
             return ((JsonEndpoint<RequestT, ResponseT, ErrorT>) endpoint).responseDeserializer();
-        }
-        else{
+        } else {
             throw new IllegalArgumentException("Expected JsonEndpooint");
         }
     }

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -6,6 +6,7 @@ import org.opensearch.client.transport.Transport;
 import org.opensearch.client.transport.TransportOptions;
 
 import com.omnia.sdk.OmniaSDK;
+
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -2,8 +2,6 @@ package com.omnia.transport;
 
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Transport;
@@ -12,7 +10,6 @@ import org.opensearch.client.transport.TransportOptions;
 import com.omnia.sdk.OmniaSDK;
 
 import javax.annotation.Nullable;
-import javax.crypto.SealedObject;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +28,7 @@ public class OmniaTransport implements OpenSearchTransport {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
         QueryMapper mapper = new QueryMapper();
         Query combinedQuery = (Query) mapper.executeQuery(request);
-        if(combinedQuery == null){
+        if (combinedQuery == null) {
             return delegate.performRequest(request, customEndpoint, options);
         }
         List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
@@ -41,7 +38,7 @@ public class OmniaTransport implements OpenSearchTransport {
         try {
             mapper.updatePrivateFields(request, combinedQuery);
             return delegate.performRequest(request, customEndpoint, options);
-        } catch (IllegalAccessException |NoSuchFieldException e) {
+        } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
     }
@@ -51,7 +48,7 @@ public class OmniaTransport implements OpenSearchTransport {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
         QueryMapper mapper = new QueryMapper();
         Query combinedQuery = (Query) mapper.executeQuery(request);
-        if(combinedQuery == null){
+        if (combinedQuery == null) {
             return delegate.performRequestAsync(request, customEndpoint, options);
         }
         List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
@@ -61,7 +58,7 @@ public class OmniaTransport implements OpenSearchTransport {
         try {
             mapper.updatePrivateFields(request, combinedQuery);
             return delegate.performRequestAsync(request, customEndpoint, options);
-        } catch (IllegalAccessException |NoSuchFieldException e) {
+        } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
     }

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -3,6 +3,7 @@ package com.omnia.transport;
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Transport;
@@ -29,40 +30,40 @@ public class OmniaTransport implements OpenSearchTransport {
     public <RequestT, ResponseT, ErrorT> ResponseT performRequest(RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, @Nullable TransportOptions options) throws IOException {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
         QueryMapper mapper = new QueryMapper();
-        if (request instanceof SearchRequest) {
-            Query combinedQuery = ((SearchRequest) request).query();
-            List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
-            for (var x : Indexes) {
-                combinedQuery = sdk.addIndexFilter(combinedQuery, x);
-            }
-            try {
-                mapper.updatePrivateFields(request, combinedQuery);
-                return delegate.performRequest(request, customEndpoint, options);
-            } catch (IllegalAccessException |NoSuchFieldException e) {
-                throw new RuntimeException(e);
-            }
+        Query combinedQuery = (Query) mapper.executeQuery(request);
+        if(combinedQuery == null){
+            return delegate.performRequest(request, customEndpoint, options);
         }
-        return delegate.performRequest(request, customEndpoint, options);
+        List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
+        for (var x : Indexes) {
+            combinedQuery = sdk.addIndexFilter(combinedQuery, x);
+        }
+        try {
+            mapper.updatePrivateFields(request, combinedQuery);
+            return delegate.performRequest(request, customEndpoint, options);
+        } catch (IllegalAccessException |NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public <RequestT, ResponseT, ErrorT> CompletableFuture<ResponseT> performRequestAsync(RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, @Nullable TransportOptions options) {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
         QueryMapper mapper = new QueryMapper();
-        if (request instanceof SearchRequest) {
-            Query combinedQuery = ((SearchRequest) request).query();
-            List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
-            for (var x : Indexes) {
-                combinedQuery = sdk.addIndexFilter(combinedQuery, x);
-            }
-            try {
-                mapper.updatePrivateFields(request, combinedQuery);
-                return delegate.performRequestAsync(request, customEndpoint, options);
-            } catch (IllegalAccessException |NoSuchFieldException e) {
-                throw new RuntimeException(e);
-            }
+        Query combinedQuery = (Query) mapper.executeQuery(request);
+        if(combinedQuery == null){
+            return delegate.performRequestAsync(request, customEndpoint, options);
         }
-        return delegate.performRequestAsync(request, customEndpoint, options);
+        List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
+        for (var x : Indexes) {
+            combinedQuery = sdk.addIndexFilter(combinedQuery, x);
+        }
+        try {
+            mapper.updatePrivateFields(request, combinedQuery);
+            return delegate.performRequestAsync(request, customEndpoint, options);
+        } catch (IllegalAccessException |NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -2,6 +2,7 @@ package com.omnia.transport;
 
 import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.transport.Endpoint;
+import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Transport;
 import org.opensearch.client.transport.TransportOptions;
 
@@ -11,7 +12,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-public class OmniaTransport implements Transport {
+public class OmniaTransport implements OpenSearchTransport {
     private final Transport delegate;
     private final OmniaSDK sdk;
 

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -1,6 +1,8 @@
 package com.omnia.transport;
 
 import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Transport;
@@ -9,7 +11,9 @@ import org.opensearch.client.transport.TransportOptions;
 import com.omnia.sdk.OmniaSDK;
 
 import javax.annotation.Nullable;
+import javax.crypto.SealedObject;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public class OmniaTransport implements OpenSearchTransport {
@@ -24,7 +28,15 @@ public class OmniaTransport implements OpenSearchTransport {
     @Override
     public <RequestT, ResponseT, ErrorT> ResponseT performRequest(RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, @Nullable TransportOptions options) throws IOException {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
-        return delegate.performRequest(request, customEndpoint, options);
+        if(request instanceof SearchRequest){
+            Query combinedQuery = ((SearchRequest) request).query();
+            List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
+            for(var x: Indexes) {
+                combinedQuery = sdk.addIndexFilter(combinedQuery,x );
+            }
+            return delegate.performRequest(((RequestT)new SearchRequest.Builder().query(combinedQuery).index(((SearchRequest) request).index()).build()), customEndpoint, options);
+        }
+        return delegate.performRequest(request,customEndpoint,options);
     }
 
     @Override

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -28,15 +28,15 @@ public class OmniaTransport implements OpenSearchTransport {
     @Override
     public <RequestT, ResponseT, ErrorT> ResponseT performRequest(RequestT request, Endpoint<RequestT, ResponseT, ErrorT> endpoint, @Nullable TransportOptions options) throws IOException {
         final OmniaEndpoint<RequestT, ResponseT, ErrorT> customEndpoint = new OmniaEndpoint<>(endpoint, sdk);
-        if(request instanceof SearchRequest){
+        if (request instanceof SearchRequest) {
             Query combinedQuery = ((SearchRequest) request).query();
             List<String> Indexes = customEndpoint.getIndex(endpoint.requestUrl(request));
-            for(var x: Indexes) {
-                combinedQuery = sdk.addIndexFilter(combinedQuery,x );
+            for (var x : Indexes) {
+                combinedQuery = sdk.addIndexFilter(combinedQuery, x);
             }
-            return delegate.performRequest(((RequestT)new SearchRequest.Builder().query(combinedQuery).index(((SearchRequest) request).index()).build()), customEndpoint, options);
+            return delegate.performRequest(((RequestT) new SearchRequest.Builder().query(combinedQuery).index(((SearchRequest) request).index()).build()), customEndpoint, options);
         }
-        return delegate.performRequest(request,customEndpoint,options);
+        return delegate.performRequest(request, customEndpoint, options);
     }
 
     @Override

--- a/transport/src/main/java/com/omnia/transport/OmniaTransport.java
+++ b/transport/src/main/java/com/omnia/transport/OmniaTransport.java
@@ -4,6 +4,7 @@ import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.transport.Endpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.Transport;
@@ -35,7 +36,7 @@ public class OmniaTransport implements OpenSearchTransport {
             try {
                 return delegate.performRequest(request, customEndpoint, options);
             } catch (OpenSearchException e) {
-                if (Objects.equals(e.error().type(), "resource_already_exists_exception")) {
+                if (Objects.equals(e.error().type(), "resource_already_exists_exception") && request instanceof CreateIndexRequest) {
                     return null;
                 }
                 throw new OpenSearchException(e.response());
@@ -52,7 +53,7 @@ public class OmniaTransport implements OpenSearchTransport {
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         } catch (OpenSearchException e) {
-            if (Objects.equals(e.error().type(), "resource_already_exists_exception")) {
+            if (Objects.equals(e.error().type(), "resource_already_exists_exception") && request instanceof CreateIndexRequest) {
                 return null;
             }
             throw new OpenSearchException(e.response());
@@ -68,7 +69,7 @@ public class OmniaTransport implements OpenSearchTransport {
             try {
                 return delegate.performRequestAsync(request, customEndpoint, options);
             } catch (OpenSearchException e) {
-                if (Objects.equals(e.error().type(), "resource_already_exists_exception")) {
+                if (Objects.equals(e.error().type(), "resource_already_exists_exception") && request instanceof CreateIndexRequest) {
                     return null;
                 }
                 throw new OpenSearchException(e.response());
@@ -84,7 +85,7 @@ public class OmniaTransport implements OpenSearchTransport {
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         } catch (OpenSearchException e) {
-            if (Objects.equals(e.error().type(), "resource_already_exists_exception")) {
+            if (Objects.equals(e.error().type(), "resource_already_exists_exception") && request instanceof CreateIndexRequest) {
                 return null;
             }
             throw new OpenSearchException(e.response());

--- a/transport/src/main/java/com/omnia/transport/QueryMapper.java
+++ b/transport/src/main/java/com/omnia/transport/QueryMapper.java
@@ -47,20 +47,20 @@ public class QueryMapper {
     public void updatePrivateFields(Object target, Query fieldValues)
             throws NoSuchFieldException, IllegalAccessException {
         Class<?> clazz = target.getClass();
-        Field field = findField(clazz);
-        if (field == null) {
+        Field queryField = findQueryField(clazz);
+        if (queryField == null) {
             throw new NoSuchFieldException(
-                    "Field '" + field.getName() + "' not found in class hierarchy");
+                    "Field 'query' not found in class hierarchy");
         }
         try {
-            field.setAccessible(true);
-            field.set(target, fieldValues);
+            queryField.setAccessible(true);
+            queryField.set(target, fieldValues);
         } catch (SecurityException e) {
             throw new IllegalAccessException("Security manager blocked access to field: " + e.getMessage());
         }
     }
 
-    private static Field findField(Class<?> clazz) {
+    private static Field findQueryField(Class<?> clazz) {
         Class<?> currentClass = clazz;
         while (currentClass != null) {
             try {

--- a/transport/src/main/java/com/omnia/transport/QueryMapper.java
+++ b/transport/src/main/java/com/omnia/transport/QueryMapper.java
@@ -1,6 +1,5 @@
 package com.omnia.transport;
 
-import org.opensearch.client.Request;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;

--- a/transport/src/main/java/com/omnia/transport/QueryMapper.java
+++ b/transport/src/main/java/com/omnia/transport/QueryMapper.java
@@ -1,0 +1,45 @@
+package com.omnia.transport;
+
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+
+import java.util.Map;
+
+public class QueryMapper {
+
+    public Query mapToQuery(Map<String, String> params){
+        return Query.of(q -> q
+                .bool(builder -> {
+                    for (Map.Entry<String, String> entry : params.entrySet()) {
+                        String key = entry.getKey();
+                        String value = entry.getValue();
+                        builder.filter(f -> f.term(t -> t
+                                .field(key)
+                                .value(v -> v.stringValue(value))
+                        ));
+                    }
+                    return builder;
+                })
+        );
+    }
+
+    public void queryToMap(Query query, Map<String, String> result) {
+        if (query.isTerm()) {
+            TermQuery term = query.term();
+            String value = term.value().stringValue();
+            result.put(term.field(), value);
+        }
+        else if (query.isMatch()) {
+            MatchQuery match = query.match();
+            result.put(match.field(), match.query().stringValue());
+        }
+        else if (query.isBool()) {
+            BoolQuery bool = query.bool();
+            bool.must().forEach(q -> queryToMap(q, result));
+            bool.should().forEach(q -> queryToMap(q, result));
+            bool.filter().forEach(q -> queryToMap(q, result));
+        }
+    }
+}

--- a/transport/src/main/java/com/omnia/transport/QueryMapper.java
+++ b/transport/src/main/java/com/omnia/transport/QueryMapper.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class QueryMapper {
 
-    public Query mapToQuery(Map<String, String> params){
+    public Query mapToQuery(Map<String, String> params) {
         return Query.of(q -> q
                 .bool(builder -> {
                     for (Map.Entry<String, String> entry : params.entrySet()) {
@@ -30,12 +30,10 @@ public class QueryMapper {
             TermQuery term = query.term();
             String value = term.value().stringValue();
             result.put(term.field(), value);
-        }
-        else if (query.isMatch()) {
+        } else if (query.isMatch()) {
             MatchQuery match = query.match();
             result.put(match.field(), match.query().stringValue());
-        }
-        else if (query.isBool()) {
+        } else if (query.isBool()) {
             BoolQuery bool = query.bool();
             bool.must().forEach(q -> queryToMap(q, result));
             bool.should().forEach(q -> queryToMap(q, result));

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -100,6 +100,10 @@ public class OmniaEndpointTest {
                 .index("123")
                 .build();
         openSearchClient.indices().create(createIndexRequest);
+        createIndexRequest = new CreateIndexRequest.Builder()
+                .index("456")
+                .build();
+        openSearchClient.indices().create(createIndexRequest);
     }
 
     private static void indexTestDocument(String name, String id) throws IOException {

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -91,13 +91,13 @@ public class OmniaEndpointTest {
 
 
         OpenSearchTransport transport = new RestClientTransport(restClient, new org.opensearch.client.json.jackson.JacksonJsonpMapper());
-        OpenSearchTransport omniatransport = new OmniaTransport(transport, sdk);
-        return new OpenSearchClient(omniatransport);
+        OpenSearchTransport omniaTransport = new OmniaTransport(transport, sdk);
+        return new OpenSearchClient(omniaTransport);
     }
 
     private static void createOpenSearchIndex() throws IOException {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder()
-                .index("commune")
+                .index("123")
                 .build();
         openSearchClient.indices().create(createIndexRequest);
     }
@@ -107,13 +107,13 @@ public class OmniaEndpointTest {
         document.put(FEATURE_NAME, name);
 
         IndexRequest<Map<String, String>> indexRequest = new IndexRequest.Builder<Map<String, String>>()
-                .index("commune")
+                .index("123")
                 .id(id)
                 .document(document)
                 .build();
 
         openSearchClient.index(indexRequest);
-        openSearchClient.indices().refresh(b -> b.index("commune")); // Refresh to make document searchable
+        openSearchClient.indices().refresh(b -> b.index("123"));
     }
 
     @Test
@@ -130,7 +130,7 @@ public class OmniaEndpointTest {
         Query baseQuery = new Query.Builder().matchAll(m -> m).build();
 
         SearchRequest request = new SearchRequest.Builder()
-                .index("123")
+                .index("456")
                 .query(baseQuery)
                 .build();
 

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -91,7 +91,7 @@ public class OmniaEndpointTest {
 
 
         OpenSearchTransport transport = new RestClientTransport(restClient, new org.opensearch.client.json.jackson.JacksonJsonpMapper());
-        OpenSearchTransport omniatransport = new OmniaTransport(transport,sdk);
+        OpenSearchTransport omniatransport = new OmniaTransport(transport, sdk);
         return new OpenSearchClient(omniatransport);
     }
 
@@ -119,7 +119,7 @@ public class OmniaEndpointTest {
     @Test
     void testCreateSearchRequestBuilder() throws IOException {
         Query baseQuery = new Query.Builder().matchAll(m -> m).build();
-        SearchRequest request =new SearchRequest.Builder()
+        SearchRequest request = new SearchRequest.Builder()
                 .index("123").query(baseQuery).build();
         SearchResponse<Object> response = openSearchClient.search(request, Object.class);
         assertEquals(1, response.hits().hits().size(), "Should find one document");

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -1,0 +1,160 @@
+package com.omnia.transport;
+
+
+import com.omnia.common.config.AppConfig;
+import com.omnia.common.config.Config;
+import com.omnia.common.config.db.Database;
+import com.omnia.common.config.db.PostgresqlParams;
+import com.omnia.sdk.OmniaSDKPostgreSQL;
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorResponse;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexResponse;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+import org.opensearch.client.opensearch.indices.RefreshRequest;
+import org.opensearch.client.transport.JsonEndpoint;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+public class OmniaEndpointTest {
+
+    private static final String FEATURE_NAME = "test-feature";
+    @Container
+    public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:13")
+            .withDatabaseName("testdb")
+            .withUsername("testuser")
+            .withPassword("testpass");
+    @Container
+    public static OpensearchContainer<?> opensearch = (OpensearchContainer<?>) new OpensearchContainer("opensearchproject/opensearch:2.9.0")
+            .withStartupTimeout(java.time.Duration.ofMinutes(5));
+    private static OmniaSDKPostgreSQL sdk;
+    private static OpenSearchClient openSearchClient;
+
+    @BeforeAll
+    static void setUp() throws SQLException, IOException {
+        // Setup PostgreSQL schema and data
+        try (Connection conn = DriverManager.getConnection(
+                postgres.getJdbcUrl(),
+                postgres.getUsername(),
+                postgres.getPassword());
+             Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE TABLE \"INDEX_TO_COMMUNE\" (\"index\" VARCHAR PRIMARY KEY, commune VARCHAR)");
+            stmt.execute("INSERT INTO \"INDEX_TO_COMMUNE\" (\"index\", commune) VALUES ('123', 'commune')");
+            stmt.execute("INSERT INTO \"INDEX_TO_COMMUNE\" (\"index\", commune) VALUES ('456', 'commune')");
+        }
+
+        AppConfig appConfig = createTestAppConfig();
+        sdk = new OmniaSDKPostgreSQL(appConfig);
+        openSearchClient = createOpenSearchClient();
+
+        createOpenSearchIndex();
+        indexTestDocument("123", "1");
+        indexTestDocument("456", "2");
+    }
+
+    private static AppConfig createTestAppConfig() {
+        PostgresqlParams postgresqlParams = new PostgresqlParams();
+        postgresqlParams.setHost(postgres.getHost());
+        postgresqlParams.setPort(postgres.getFirstMappedPort());
+        postgresqlParams.setDatabaseName(postgres.getDatabaseName());
+        postgresqlParams.setUsername(postgres.getUsername());
+        postgresqlParams.setPassword(postgres.getPassword());
+
+        Database database = new Database();
+        database.setType("postgresql");
+        database.setParams(postgresqlParams.toParams());
+
+        AppConfig appConfig = new AppConfig();
+        appConfig.setConfig(new Config());
+        appConfig.setDatabase(database);
+        appConfig.getConfig().setFeatureName(FEATURE_NAME);
+
+        return appConfig;
+    }
+
+    private static OpenSearchClient createOpenSearchClient() throws IOException {
+        RestClient restClient = RestClient.builder(
+                new HttpHost(opensearch.getHost(), opensearch.getMappedPort(9200))
+        ).build();
+        OpenSearchTransport transport = new RestClientTransport(restClient, new org.opensearch.client.json.jackson.JacksonJsonpMapper());
+        OpenSearchTransport omniaTransport = new OmniaTransport(transport, sdk);
+        return new OpenSearchClient(omniaTransport);
+    }
+
+    private static void createOpenSearchIndex() throws IOException {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder()
+                .index("commune")
+                .build();
+        OpenSearchIndicesClient a = openSearchClient.indices();
+        a.create(createIndexRequest);
+    }
+
+    private static void indexTestDocument(String name, String id) throws IOException {
+        Map<String, String> document = new HashMap<>();
+        document.put(FEATURE_NAME, name);
+
+        IndexRequest<Map<String, String>> indexRequest = new IndexRequest.Builder<Map<String, String>>()
+                .index("commune")
+                .id(id)
+                .document(document)
+                .build();
+
+        openSearchClient.index(indexRequest);
+        openSearchClient.indices().refresh(b -> b.index("commune"));
+    }
+
+    @Test
+    void testCreateSearchRequestBuilder() throws IOException {
+        SearchRequest.Builder requestBuilder = sdk.createSearchRequestBuilder("123");
+        SearchRequest request = requestBuilder.build();
+
+        SearchResponse<Object> response = openSearchClient.search(request, Object.class);
+        assertEquals(1, response.hits().hits().size(), "Should find one document");
+    }
+
+    @Test
+    void testAddIndexFilter() throws IOException {
+        Query baseQuery = new Query.Builder().matchAll(m -> m).build();
+        Query combinedQuery = sdk.addIndexFilter(baseQuery, "123");
+
+        SearchRequest request = new SearchRequest.Builder()
+                .index("commune")
+                .query(combinedQuery)
+                .build();
+
+        SearchResponse<Object> response = openSearchClient.search(request, Object.class);
+        assertEquals(1, response.hits().hits().size(), "Combined query should find one document");
+    }
+
+    @Test
+    void testGetFilterField() {
+        assertEquals(FEATURE_NAME, sdk.getFilterField(), "Filter field should match feature name from config");
+    }
+
+}

--- a/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
+++ b/transport/src/test/java/com/omnia/transport/OmniaEndpointTest.java
@@ -56,7 +56,7 @@ public class OmniaEndpointTest {
              Statement stmt = conn.createStatement()) {
 
             stmt.execute("CREATE TABLE \"INDEX_TO_COMMUNE\" (\"index\" VARCHAR PRIMARY KEY, commune VARCHAR)");
-            stmt.execute("INSERT INTO \"INDEX_TO_COMMUNE\" (\"index\", commune) VALUES ('123', 'commune'), ('456', 'commune') ,('123A', 'commune')");   
+            stmt.execute("INSERT INTO \"INDEX_TO_COMMUNE\" (\"index\", commune) VALUES ('123', 'commune'), ('456', 'commune') ,('123A', 'commune')");
         }
 
         AppConfig appConfig = createTestAppConfig();

--- a/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
+++ b/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
@@ -1,6 +1,7 @@
 package com.omnia.transport;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
@@ -59,5 +60,33 @@ public class QueryMapperTest<RequestT, ResponseT, ErrorT>  {
         assertEquals("debug", result.get("level"));
         assertEquals("log", result.get("type"));
     }
+    @Test
+    void queryToMap_MatchQueryTest() {
+        MatchQuery matchQuery = new MatchQuery.Builder()
+                .field("title")
+                .query(q -> q.stringValue("OpenSearch"))
+                .build();
+        Query query = new Query.Builder()
+                .match(matchQuery)
+                .build();
+        Map<String, String> resultMap = new HashMap<>();
+        mapper.queryToMap(query, resultMap);
+        assertEquals(1, resultMap.size());
+        assertEquals("OpenSearch", resultMap.get("title"));
+    }
 
+    @Test
+    void queryToMap_termQuerytest() {
+        Query query = new Query.Builder()
+                .term(t -> t
+                        .field("title")
+                        .value(v -> v.stringValue("OpenSearch"))
+                )
+                .build();
+
+        Map<String, String> resultMap = new HashMap<>();
+        mapper.queryToMap(query, resultMap);
+        assertEquals(1, resultMap.size());
+        assertEquals("OpenSearch", resultMap.get("title"));
+    }
 }

--- a/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
+++ b/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
@@ -1,4 +1,5 @@
 package com.omnia.transport;
+
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
@@ -11,10 +12,11 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class QueryMapperTest<RequestT, ResponseT, ErrorT>  {
+public class QueryMapperTest<RequestT, ResponseT, ErrorT> {
     QueryMapper mapper = new QueryMapper();
+
     @Test
-    void mapToQuery_simpleTest(){
+    void mapToQuery_simpleTest() {
         Map<String, String> params = new HashMap<>();
         params.put("name", "Alice");
         params.put("age", "18");
@@ -60,6 +62,7 @@ public class QueryMapperTest<RequestT, ResponseT, ErrorT>  {
         assertEquals("debug", result.get("level"));
         assertEquals("log", result.get("type"));
     }
+
     @Test
     void queryToMap_MatchQueryTest() {
         MatchQuery matchQuery = new MatchQuery.Builder()

--- a/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
+++ b/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
@@ -46,7 +46,7 @@ public class QueryMapperTest<RequestT, ResponseT, ErrorT> {
 
 
     @Test
-    void queryToMap_simpleBoolQueries() {
+    void queryToMap_simpleBoolQueryTest() {
         QueryMapper mapper = new QueryMapper();
         Map<String, String> result = new HashMap<>();
         Query nestedBool = Query.of(b -> b.bool(bb -> bb
@@ -79,14 +79,13 @@ public class QueryMapperTest<RequestT, ResponseT, ErrorT> {
     }
 
     @Test
-    void queryToMap_termQuerytest() {
+    void queryToMap_termQueryTest() {
         Query query = new Query.Builder()
                 .term(t -> t
                         .field("title")
                         .value(v -> v.stringValue("OpenSearch"))
                 )
                 .build();
-
         Map<String, String> resultMap = new HashMap<>();
         mapper.queryToMap(query, resultMap);
         assertEquals(1, resultMap.size());

--- a/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
+++ b/transport/src/test/java/com/omnia/transport/QueryMapperTest.java
@@ -1,0 +1,63 @@
+package com.omnia.transport;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QueryMapperTest<RequestT, ResponseT, ErrorT>  {
+    QueryMapper mapper = new QueryMapper();
+    @Test
+    void mapToQuery_simpleTest(){
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "Alice");
+        params.put("age", "18");
+        Query query = mapper.mapToQuery(params);
+        BoolQuery boolQuery = query.bool();
+        assertEquals(2, boolQuery.filter().size());
+        Query firstFilter = boolQuery.filter().get(0);
+        assertTrue(firstFilter.isTerm());
+        TermQuery firstTerm = firstFilter.term();
+        assertEquals("name", firstTerm.field());
+        assertEquals("Alice", firstTerm.value().stringValue());
+        Query secondFilter = boolQuery.filter().get(1);
+        assertTrue(secondFilter.isTerm());
+        TermQuery secondTerm = secondFilter.term();
+        assertEquals("age", secondTerm.field());
+        assertEquals("18", secondTerm.value().stringValue());
+    }
+
+    @Test
+    void mapToQuery_emptyTest() {
+        Map<String, String> params = new HashMap<>();
+        QueryMapper mapper = new QueryMapper();
+        Query query = mapper.mapToQuery(params);
+        assertTrue(query.isBool());
+        assertTrue(query.bool().filter().isEmpty());
+    }
+
+
+    @Test
+    void queryToMap_simpleBoolQueries() {
+        QueryMapper mapper = new QueryMapper();
+        Map<String, String> result = new HashMap<>();
+        Query nestedBool = Query.of(b -> b.bool(bb -> bb
+                .must(m -> m.term(t -> t.field("level").value(FieldValue.of("debug"))))
+        ));
+        Query mainQuery = Query.of(b -> b.bool(bb -> bb
+                .must(nestedBool)
+                .filter(f -> f.match(m -> m.field("type").query(FieldValue.of("log"))))
+        ));
+
+        mapper.queryToMap(mainQuery, result);
+        assertEquals(2, result.size());
+        assertEquals("debug", result.get("level"));
+        assertEquals("log", result.get("type"));
+    }
+
+}


### PR DESCRIPTION
Added: tests for QuerryMapper and OmniaTransport
Modified: OmniaTrasport, transport supports all types of requests using reflection
:cactus: :cry: 